### PR TITLE
Improve async signal safety

### DIFF
--- a/blackbox.h
+++ b/blackbox.h
@@ -47,7 +47,7 @@ int init(std::size_t size = DEFAULT_SIZE) noexcept;
 // On failure, returns negative error code. The returned value is suitable
 // for std::strerror(-ret).
 //
-// These are not safe to call in signal handlers.
+// These are safe to call inside signal handlers.
 int write(std::string_view s) noexcept;
 int write(std::int64_t i) noexcept;
 int write(std::string_view key, std::string_view value) noexcept;

--- a/blackbox.h
+++ b/blackbox.h
@@ -16,8 +16,8 @@
 //    3. Outside the application (after a crash)
 //
 // The blackbox is designed with data consistency in mind. It is always
-// possible to extract consistent a consistent snapshot while the process is
-// alive (assuming a reasonable amount of writes). In the event the application
+// possible to extract a consistent snapshot while the process is alive
+// (assuming a reasonable amount of writes). In the event the application
 // crashes, the extractor will be able to detect any inconsistency.
 
 namespace blackbox {

--- a/extractor/extractor.cpp
+++ b/extractor/extractor.cpp
@@ -119,6 +119,11 @@ std::unique_ptr<Blackbox, std::function<void(Blackbox *)>> grab(int pid) {
 
   // Allocate enough memory to hold entire blackbox
   auto blackbox = static_cast<Blackbox *>(::malloc(sb.st_size));
+  if (!blackbox) {
+    auto err = std::strerror(ENOMEM);
+    std::cerr << "malloc failed: " << err << std::endl;
+    return nullptr;
+  }
 
   // Copy out entire blackbox to minimize critical section.
   bool success = copy(blackbox, static_cast<Blackbox *>(ptr));


### PR DESCRIPTION
Currently, dump is async signal safe by using a try lock, but write_locked isn't. Try lock works fine but is susceptible to spurious failures in case of contention (even from a non-signal handler context).

Instead, we can use a thread_local sig_atomic_t to mark the beginning of the critical section per thread, to detect AA deadlocks from signal handler contexts (potentially nesting more than once), just like in the kernel with per-CPU variables.

This permits write_locked to be safely invoked inside a signal handler, and dump to only fail if it interrupts a critical section on the local thread.

Note that we need to mark lock_taken even in dump, for two reasons: First, write_locked may interrupt dump, just as dump may interrupt write_locked. Second, we may begin waiting in write_locked after interrupting dump while the owner (lower context) may never make progress because we keep waiting while having interrupted it.

More details are in the commit log.

There's a couple minor fixes I noticed while looking through the code, the first two commits are about that.