### PR TITLE
Handle moved-from state in ~SignalSafeLock

### DIFF
--- a/blackbox.cpp
+++ b/blackbox.cpp
@@ -48,11 +48,18 @@ class SignalSafeLock {
     return SignalSafeLock();
   }
 
-  SignalSafeLock(SignalSafeLock &&) = default;
+  // Locks are non-copyable
+  SignalSafeLock(const SignalSafeLock &) = delete;
+  SignalSafeLock &operator=(const SignalSafeLock &) = delete;
+
+  SignalSafeLock(SignalSafeLock &&other) = default;
 
   ~SignalSafeLock() {
-    lock_.unlock();
-    lock_taken = 0;
+    // Do nothing if we are in moved-from state
+    if (lock_.owns_lock()) {
+      lock_.unlock();
+      lock_taken = 0;
+    }
   }
 
  private:


### PR DESCRIPTION
Previously, running `demo` resulting in a std::system_error exception
with the following backtrace:

    [...]
    #10 0x00007ffff74a7af3 in std::__throw_system_error(int) () from /lib64/libstdc++.so.6
    #11 0x00007ffff7f6ce65 in std::unique_lock<std::mutex>::unlock (this=0x7ffff51090a0)
        at /usr/include/c++/13/bits/unique_lock.h:194
    #12 blackbox::(anonymous namespace)::SignalSafeLock::~SignalSafeLock (this=0x7ffff51090a0,
        __in_chrg=<optimized out>) at blackbox.cpp:56
    #13 blackbox::(anonymous namespace)::SignalSafeLock::grabLock () at blackbox.cpp:48
    #14 blackbox::(anonymous namespace)::write_locked<blackbox::(anonymous namespace)::insert(blackbox::internal::Type, void*, uint64_t)::<lambda()> >(struct {...} &&) (f=...) at blackbox.cpp:73
    #15 0x00007ffff7f6d25d in blackbox::(anonymous namespace)::insert (entry_size=<optimized out>,
        entry=<optimized out>, type=<optimized out>) at blackbox.cpp:264
    #16 blackbox::write (s=...) at blackbox.cpp:298

Reason was that returning `SignalSafeLock()` in factory method caused a
implicit move. Which is fine and correct. But this means there are two
destructions: one for moved-to object and one for moved-from.

We did not previously handle moved-from destruction correctly and
unlocked an empty unique_lock. This triggered the exception.

Fix by implementing proper destructor. Also delete copy constructors to
complete "rule of 5" (for posterity).