### PR TITLE
Tests for SignalSafeLock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX = g++
 CXXFLAGS = -std=c++20 -Wall -Wextra -Werror -O3 -fsanitize=address
 
-all: extractor/extractor demo/demo
+all: extractor/extractor demo/demo tests/test
 
 libblackbox.so: blackbox.cpp internal.h
 	$(CXX) $(CXXFLAGS) -fPIC -shared blackbox.cpp -o libblackbox.so -g
@@ -12,7 +12,10 @@ extractor/extractor: extractor/extractor.cpp internal.h
 demo/demo: demo/demo.cpp libblackbox.so
 	$(CXX) $(CXXFLAGS) $< -L. -lblackbox -Wl,-rpath,. -I. -o $@ -g
 
+tests/test: tests/test.cpp libblackbox.so
+	$(CXX) $(CXXFLAGS) $< -L. -lgtest -lblackbox -Wl,-rpath,. -I. -o $@ -g
+
 clean:
-	rm -f extractor/extractor demo/demo libblackbox.so
+	rm -f tests/test extractor/extractor demo/demo libblackbox.so
 
 .PHONY: all clean

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,0 +1,104 @@
+#include <blackbox.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <csignal>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+std::atomic_bool signal_nesting_error;
+std::atomic_bool signal_thread_started;
+
+void SignalHandler(int signal) {
+  if (signal == SIGUSR1) {
+    if (blackbox::write("test") == -EDEADLK) {
+      signal_nesting_error.store(true);
+    }
+    return;
+  }
+
+  std::ostream dummy(0);
+  if (signal == SIGUSR2) {
+    if (blackbox::dump(dummy) == -EDEADLK) {
+      signal_nesting_error.store(true);
+    }
+  }
+}
+
+enum blackbox_ops {
+  OP_WRITE,
+  OP_DUMP,
+};
+
+void SignalHandlerNesting(blackbox_ops main_op, blackbox_ops sig_op) {
+  signal_nesting_error.store(false);
+  signal_thread_started.store(false);
+
+  int signal = sig_op == OP_WRITE ? SIGUSR1 : SIGUSR2;
+
+  std::jthread thread([&] {
+    sigset_t signal_set;
+    sigemptyset(&signal_set);
+    sigaddset(&signal_set, signal);
+    EXPECT_EQ(::pthread_sigmask(SIG_UNBLOCK, &signal_set, nullptr), 0);
+    struct sigaction sa;
+    sa.sa_handler = SignalHandler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    EXPECT_EQ(::sigaction(signal, &sa, nullptr), 0);
+
+    signal_thread_started.store(true);
+
+    while (!signal_nesting_error.load()) {
+      switch (main_op) {
+	case OP_WRITE: {
+	  blackbox::write("test");
+	  break;
+	}
+	case OP_DUMP: {
+	  std::ostream dummy(0);
+	  blackbox::dump(dummy);
+	  break;
+	}
+      }
+    }
+  });
+
+  while (!signal_thread_started.load());
+
+  while (!signal_nesting_error.load()) {
+    ::pthread_kill(thread.native_handle(), signal);
+    std::this_thread::sleep_for(1ms);
+  }
+}
+
+}  // namespace
+
+TEST(blackbox, signal_nesting_dump_dump) {
+  SignalHandlerNesting(OP_DUMP, OP_DUMP);
+}
+
+TEST(blackbox, signal_nesting_dump_write) {
+  SignalHandlerNesting(OP_DUMP, OP_WRITE);
+}
+
+TEST(blackbox, signal_nesting_write_dump) {
+  SignalHandlerNesting(OP_WRITE, OP_DUMP);
+}
+
+TEST(blackbox, signal_nesting_write_write) {
+  SignalHandlerNesting(OP_WRITE, OP_WRITE);
+}
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  blackbox::init();
+  for (int i = 0; i < 100; i++) {
+    blackbox::write("key=1", "value=1");
+  }
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is the first stab, let me know what you think about organization / idioms etc. that are preferred when adding tests, and ideas on how to better do something like this.

I ran out of time today but will debug the one that is harder to reproduce in a reasonable time, i.e. the write_dump interleaving, it can take a few seconds (or stall for 10s of seconds), so it's a bit indeterministic right now, but it does work. I will rebase once the fix for SignalSafeLock in #2 is merged, but it appears to do the right thing otherwise.